### PR TITLE
Fix to better handle stat and force refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add ESC Explorer feature
 - Add IaC Debugging feature
 - Incorporate Pulumi LSP
+- Update ESC refresh after update


### PR DESCRIPTION
Right now the watch does behave reliably. Since we do not have a full metadata endpoint with the right permissions, this change:

In stat:
- Uses Date.now() as default mtime, randomInt as default size.
- If the change is open, use the date from the environment uri

After we do a read, we set a proper size.  

If we update the file we clear size  so the next stat is random (cannot trust our file size).  We also set the mtime to the current date.

We are also properly keeping track of watches and if the file changes any opens are also marked changed so they are refreshed automatically. 