### PR TITLE
Fix "Add to terminal" command separator

### DIFF
--- a/src/esc/commands.ts
+++ b/src/esc/commands.ts
@@ -182,7 +182,7 @@ export function runCommand(): vscode.Disposable {
             return;
         }
 
-        terminal.sendText(`esc run ${env.org}/${env.project}/${env.envName} --- `, false);
+        terminal.sendText(`esc run ${env.org}/${env.project}/${env.envName} -- `, false);
         terminal.show();
     });
 }


### PR DESCRIPTION
When I use the "Add to terminal" option, it currently prints the following to the terminal, which results in an error:

```
$ esc run cnunciato/default/personal --- echo "hi"          
Error: bad flag syntax: ---
```

I believe it should be two hyphens instead:

```
$ esc run cnunciato/default/personal -- echo "hi"          
hi
```