### PR TITLE
add Pulumi Copilot to extension pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- Add Pulumi Copilot to extension pack
+
 ## v0.1.0
 - Initial release
 - Add ESC Explorer feature

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   ],
   "extensionDependencies": [],
   "extensionPack": [
-    "pulumi.pulumi-lsp-client"
+    "pulumi.pulumi-lsp-client",
+    "pulumi.pulumi-vscode-copilot"
   ],
   "activationEvents": [
     "onDebugDynamicConfigurations:pulumi",


### PR DESCRIPTION
This PR adds the new [Pulumi Copilot](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot) extension to the extension pack. 

### Walkthrough
Clean installation of the Pulumi extension, automatically including Copilot.

https://github.com/user-attachments/assets/bfac2449-3a11-4b12-b331-6434fb9beaec

Uninstall (or disable) of Copilot by itself:

https://github.com/user-attachments/assets/93a49923-f9ba-4feb-b1fe-3e21cfb36f79


