### PR TITLE
Login message tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fix for debugging with a self-managed backend #20
 - Extension should install the latest CLI #12
 - Add Pulumi Copilot to extension pack
+- New welcome text for the ESC Explorer
 
 ## v0.1.0
 - Initial release

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "viewsWelcome": [
       {
         "view": "pulumi-esc-explorer",
-        "contents": "Welcome to Pulumi ESC! You will now be able to view and modify your ESC Environments inside VSCode.  To get started, login to Pulumi Cloud. \n[Login to Pulumi](command:pulumi.login)."
+        "contents": "Welcome to Pulumi ESC! You will now be able to view and modify your ESC Environments inside VSCode.  To get started, connect to Pulumi Cloud. \n[Connect to Pulumi Cloud](command:pulumi.login)\n"
       }
     ],
     "debuggers": [


### PR DESCRIPTION
Tweaks the message for the edge case where the user is already signed in and the extension is simply lacking trust. There's no way to disambiguate those cases, so we relax the wording.  

<img width="404" alt="image" src="https://github.com/user-attachments/assets/27503f15-bf72-4258-b135-0ad7157fb641" />


Also, changed the link to a button for consistency with other explorers, which resemble:

<img width="435" alt="image" src="https://github.com/user-attachments/assets/e37153d0-55b3-4b78-bebd-2b08d026ae7e" />