### PR TITLE
Respect workspace folder for auto debug configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Ability to stop debugging #11
+- Respect workspace folder for auto debug configurations #31
 
 ## v0.1.0
 - Initial release

--- a/src/iac/index.ts
+++ b/src/iac/index.ts
@@ -108,7 +108,11 @@ class PulumiDynamicConfigurationProvider implements vscode.DebugConfigurationPro
 	 * provideDebugConfigurations is called to provide automatic launch configurations without requiring a launch.json.
 	 */
 	provideDebugConfigurations(folder: WorkspaceFolder | undefined): ProviderResult<DebugConfiguration[]> {
-		return vscode.workspace.findFiles('Pulumi.yaml').then((uris) => {
+		if (!folder) {
+			return [];
+		}
+		const pattern = new vscode.RelativePattern(folder, 'Pulumi.yaml');
+		return vscode.workspace.findFiles(pattern).then((uris) => {
 			if (uris.length === 0) {
 				return [];
 			}


### PR DESCRIPTION
The "automatic debug configurations" experience wasn't working as it used to, there's an unexpected entry for "user settings".

<img width="958" alt="image" src="https://github.com/user-attachments/assets/aba3535b-b986-473e-9f98-d1f017ebd114" />

Fix: The extension wasn't respecting the folder argument of the API.  I tested in various single-folder and multi-folder workspaces, seems to work as expected.