### PR TITLE
Add Support for multiple projects in a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- Add support to multiple projects inside a workspace #34
+
 ## v0.3.0
 
 - Ability to stop debugging #11


### PR DESCRIPTION
This PR adds support to workspaces that contain multiple nested Pulumi projects.
It generates multiple launch configurations for each Pulumi project found inside the workspace folders (even nested ones).

Co-authored by: @mbovo