### PR TITLE
Remove deprecated Pulumi Copilot from the extension pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Added support for Open Approvals in Pulumi ESC
+- Removed the deprecated Pulumi Copilot extension from the extension pack
 
 ## v0.4.0
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   ],
   "extensionDependencies": [],
   "extensionPack": [
-    "pulumi.pulumi-lsp-client",
-    "pulumi.pulumi-vscode-copilot"
+    "pulumi.pulumi-lsp-client"
   ],
   "activationEvents": [
     "onDebugDynamicConfigurations:pulumi",


### PR DESCRIPTION
Part of deprecating [Pulumi Copilot for VS Code](https://marketplace.visualstudio.com/items?itemName=pulumi.pulumi-vscode-copilot). Effectively reverts #26, which added the extension to the pack in January 2025.

Removing `pulumi.pulumi-vscode-copilot` from `extensionPack` stops new installs of the Pulumi extension from automatically pulling in Copilot.

### What this does *not* do

VS Code does not uninstall an extension when it leaves a pack, so the ~12k existing installs keep the extension and it keeps working. Disabling it for existing users requires a server-side change to the `POST /api/ai/chat/preview` endpoint it calls — tracked separately.

### Notes

- No version bump here; this repo bumps `version` in a separate release-prep commit, so the changelog entry goes under `[Unreleased]`.
- `pulumi.pulumi-vscode-copilot` declares `pulumi.pulumi-vscode-tools` in its own `extensionDependencies` (it borrows the `pulumi` authentication provider from this extension). That direction is unaffected by this change — users who still have Copilot installed continue to get auth from this extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)